### PR TITLE
Save sword statement and prohibit redeposits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/swordappv2"]
 	path = libs/swordappv2
-	url = https://github.com/swordapp/swordappv2-php-library
+	url = https://github.com/quoideneuf/swordappv2-php-library

--- a/SwordHandler.inc.php
+++ b/SwordHandler.inc.php
@@ -71,11 +71,13 @@ class SwordHandler extends Handler {
 		$collections = DepositPointsHelper::loadCollectionsFromServer(
 			$depositPoint->getSwordUrl(),
 			$depositPoint->getSwordUsername(),
-			$depositPoint->getSwordPassword()
+			$depositPoint->getSwordPassword(),
+			$depositPoint->getSwordApikey()
 		);
 		return new JSONMessage(true, array(
 			'username' => $depositPoint->getSwordUsername(),
 			'password' => SWORD_PASSWORD_SLUG,
+			'apikey' => $depositPoint->getSwordApikey(),
 			'depositPoints' => $collections,
 		));
 	}

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -121,6 +121,7 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 					'pluginJavaScriptURL' 		=> $this->getSwordPlugin()->getJsUrl($request),
 					'selectSubmissionsListData' 	=> $selectSubmissionsConfig,
 				));
+
 				$templateMgr->display($this->_parentPlugin->getTemplateResource('articles.tpl'));
 				break;
 
@@ -145,6 +146,10 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 				$username = $request->getUserVar('swordUsername');
 				$depositIds = array();
 
+				if ($request->getUserVar('swordApiKey')) {
+					$swordDepositPoint = $swordDepositPoint . "?apiToken=" . urlencode(
+						$request->getUserVar('swordApiKey'));
+				}
 				$backLink = $request->url(
 					null, null, null,
 					array('plugin', $this->getName()),

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -38,8 +38,21 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	public function register($category, $path) {
 		$success = parent::register($category, $path);
 		$this->addLocaleData();
+		HookRegistry::register('publishedarticledao::getAdditionalFieldNames', array($this, 'getAdditionalFieldNames'));
 		return $success;
 	}
+
+	/**
+	 * Add statementIRI element to the article
+	 * @param $hookName string
+	 * @param $params array
+	 */
+	function getAdditionalFieldNames($hookName, $params) {
+		$fields =& $params[1];
+		$fields[] = 'swordStatementIri';
+		return false;
+	}
+
 
 	/**
 	 * Get reference to the sword plugin
@@ -79,6 +92,7 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	 * @param $args array
 	 * @param $request PKPRequest
 	 */
+
 	public function display($args, $request) {
 		parent::display($args, $request);
 		$templateMgr = TemplateManager::getManager($request);
@@ -110,7 +124,17 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 						'status'	=> STATUS_PUBLISHED,
 					),
 				));
-				$selectSubmissionsConfig = json_encode($selectSubmissionsListHandler->getConfig());
+				$publishedArticleDao = DAORegistry::getDAO('PublishedArticleDAO');
+				$selectSubmissionsConfig = $selectSubmissionsListHandler->getConfig();
+				$depositedIds = [];
+				foreach ($selectSubmissionsConfig['items'] as $item) {
+					$publishedArticle = $publishedArticleDao->getByArticleId($item['id']);
+					if ($ssi = $publishedArticle->getData("swordStatementIri")) {
+						$depositedIds[$item['id']] = json_decode($ssi, true);
+					}
+				}
+				$selectSubmissionsConfig = json_encode($selectSubmissionsConfig);
+
 
 				$templateMgr->assign(array(
 					'selectedDepositPoint' 		=> $request->getUserVar('selectedDepositPoint'),
@@ -119,9 +143,14 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 					'swordSettingsPageUrl' 		=> $settingUrl,
 					'depositPoints' 		=> $depositPointsData,
 					'pluginJavaScriptURL' 		=> $this->getSwordPlugin()->getJsUrl($request),
-					'selectSubmissionsListData' 	=> $selectSubmissionsConfig,
+					'selectSubmissionsListData' 	=> $selectSubmissionsConfig
 				));
-
+				$script = '$(document).data("depositedIdMap", '. json_encode($depositedIds) .');';
+				$templateMgr->addJavaScript('depositedIds', $script, ['inline' => true, 'contexts' => 'backend']);
+				$templateMgr->addJavaScript(
+					'disableDepositedIds',
+					$this->getSwordPlugin()->getJsUrl($request) .'/SwordDisableDepositedItems.js',
+					['contexts' => 'backend']);
 				$templateMgr->display($this->_parentPlugin->getTemplateResource('articles.tpl'));
 				break;
 
@@ -181,6 +210,20 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 								$request->getUserVar('swordApiKey'));
 							switch ($response->sac_status) {
 							case 200:
+								$stmt_link = array_shift(
+									array_filter($response->sac_links, function($link) {
+										return $link->sac_linkrel == 'http://purl.org/net/sword/terms/statement';
+									}));
+								$stmt_href = $stmt_link->sac_linkhref->__toString();
+								$data = $publishedArticle->getAllData();
+								$ssi = [];
+								if (array_has($data, 'swordStatementIri')) {
+									$ssi = unserialize($data['swordStatementIri'], true);
+								}
+								$ssi[$depositPointId] = $stmt_href;
+								$publishedArticle->setData('swordStatementIri', serialize($ssi));
+								$publishedArticleDao->updateDataObjectSettings(
+									'submission_settings', $publishedArticle, ['submission_id' => $articleId]);
 								$deposit->cleanup();
 								$depositIds[] = $response->sac_id;
 								break;

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -146,10 +146,6 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 				$username = $request->getUserVar('swordUsername');
 				$depositIds = array();
 
-				if ($request->getUserVar('swordApiKey')) {
-					$swordDepositPoint = $swordDepositPoint . "?apiToken=" . urlencode(
-						$request->getUserVar('swordApiKey'));
-				}
 				$backLink = $request->url(
 					null, null, null,
 					array('plugin', $this->getName()),
@@ -178,7 +174,11 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 							if ($depositGalleys) $deposit->addGalleys();
 							if ($depositEditorial) $deposit->addEditorial();
 							$deposit->createPackage();
-							$response = $deposit->deposit($swordDepositPoint, $username, $password);
+							$response = $deposit->deposit(
+								$swordDepositPoint,
+								$username,
+								$password,
+								$request->getUserVar('swordApiKey'));
 							switch ($response->sac_status) {
 							case 200:
 								$deposit->cleanup();

--- a/classes/DepositPoint.inc.php
+++ b/classes/DepositPoint.inc.php
@@ -105,6 +105,22 @@ class DepositPoint extends DataObject {
 	}
 
 	/**
+	 * Get SWORD api_key
+	 * @return string
+	 */
+	public function getSwordApikey() {
+		return $this->getData('swordApikey');
+	}
+
+	/**
+	 * Set SWORD api_key
+	 * @param $swordApikey string
+	 */
+	public function setSwordApikey($swordApikey) {
+		return $this->setData('swordApikey', $swordApikey);
+	}
+    
+	/**
 	 * Get SWORD url
 	 * @return string
 	 */

--- a/classes/DepositPointDAO.inc.php
+++ b/classes/DepositPointDAO.inc.php
@@ -74,6 +74,7 @@ class DepositPointDAO extends DAO {
 		$depositPoint->setType($row['type']);
 		$depositPoint->setSwordUsername($row['sword_username']);
 		$depositPoint->setSwordPassword($row['sword_password']);
+		$depositPoint->setSwordApikey($row['sword_apikey']);
 		
 		$this->getDataObjectSettings(
 			'deposit_point_settings',
@@ -98,9 +99,10 @@ class DepositPointDAO extends DAO {
 				seq,
 				type,
 				sword_username,
-				sword_password)
+				sword_password,
+				sword_apikey)
 			VALUES
-				(?, ?, ?, ?, ?, ?)',
+				(?, ?, ?, ?, ?, ?, ?)',
 			array(
 				$depositPoint->getContextId(),
 				$depositPoint->getSwordUrl(),
@@ -108,6 +110,7 @@ class DepositPointDAO extends DAO {
 				$depositPoint->getType(),
 				$depositPoint->getSwordUsername(),
 				$depositPoint->getSwordPassword(),
+				$depositPoint->getSwordApikey(),
 			)
 		);
 		$depositPoint->setId($this->getInsertId());
@@ -149,7 +152,8 @@ class DepositPointDAO extends DAO {
 					seq = ?,
 					type = ?,
 					sword_username = ?,
-					sword_password = ?
+					sword_password = ?,
+					sword_apikey = ?
 			WHERE deposit_point_id = ?',
 			array(
 				$depositPoint->getContextId(),
@@ -158,6 +162,7 @@ class DepositPointDAO extends DAO {
 				$depositPoint->getType(),
 				$depositPoint->getSwordUsername(),
 				$depositPoint->getSwordPassword(),
+				$depositPoint->getSwordApikey(),
 				$depositPoint->getId()
 			)
 		);

--- a/classes/DepositPointsHelper.inc.php
+++ b/classes/DepositPointsHelper.inc.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * @file plugins/generic/sword/classes/DepositPointsHelper.inc.php
  *
@@ -23,16 +23,19 @@ class DepositPointsHelper {
 	 * @param $password string
 	 * @return array|null
 	 */
-	public static function loadCollectionsFromServer($url, $username, $password) {
-		if (empty($url) OR empty($username) OR empty($password)) {
-			return null;
+	public static function loadCollectionsFromServer($url, $username, $password, $apikey) {
+		if ($apikey) {
+			$url = $url . "?apiToken=" . urlencode($apikey);
 		}
 		$depositPoints = array();
 		$client = new SWORDAPPClient();
 		$doc = $client->servicedocument($url, $username, $password, '');
+		if ($doc->sac_status != 200) {
+			return array('#' => 'Service Document Unreachable');
+		}
 		if (is_array($doc->sac_workspaces)) {
 			foreach ($doc->sac_workspaces as $workspace) {
-				if (is_array($workspace->sac_collections)) { 
+				if (is_array($workspace->sac_collections)) {
 					foreach ($workspace->sac_collections as $collection) {
 						$depositPoints["$collection->sac_href"] = "$collection->sac_colltitle";
 					}

--- a/classes/DepositPointsHelper.inc.php
+++ b/classes/DepositPointsHelper.inc.php
@@ -24,11 +24,8 @@ class DepositPointsHelper {
 	 * @return array|null
 	 */
 	public static function loadCollectionsFromServer($url, $username, $password, $apikey) {
-		if ($apikey) {
-			$url = $url . "?apiToken=" . urlencode($apikey);
-		}
 		$depositPoints = array();
-		$client = new SWORDAPPClient();
+		$client = new SWORDAPPClient([CURLOPT_HTTPHEADER => ["X-Ojs-Sword-Api-Token:".$apikey]]);
 		$doc = $client->servicedocument($url, $username, $password, '');
 		if ($doc->sac_status != 200) {
 			return array('#' => 'Service Document Unreachable');

--- a/classes/DepositPointsHelper.inc.php
+++ b/classes/DepositPointsHelper.inc.php
@@ -23,9 +23,10 @@ class DepositPointsHelper {
 	 * @param $password string
 	 * @return array|null
 	 */
-	public static function loadCollectionsFromServer($url, $username, $password, $apikey) {
+	public static function loadCollectionsFromServer($url, $username, $password, $apikey = null) {
 		$depositPoints = array();
-		$client = new SWORDAPPClient([CURLOPT_HTTPHEADER => ["X-Ojs-Sword-Api-Token:".$apikey]]);
+		$clientOpts = $apikey ? [CURLOPT_HTTPHEADER => ["X-Ojs-Sword-Api-Token:".$apikey]] : array();
+		$client = new SWORDAPPClient($clientOpts);
 		$doc = $client->servicedocument($url, $username, $password, '');
 		if ($doc->sac_status != 200) {
 			return array('#' => 'Service Document Unreachable');

--- a/classes/OJSSwordDeposit.inc.php
+++ b/classes/OJSSwordDeposit.inc.php
@@ -175,8 +175,12 @@ class OJSSwordDeposit {
 	 * @param $username string SWORD deposit username (i.e. email address for DSPACE)
 	 * @param $password string SWORD deposit password
 	 */
-	public function deposit($url, $username, $password) {
-		$client = new SWORDAPPClient();
+	public function deposit($url, $username, $password, $apikey = '') {
+		$client_opts = array();
+		if (!empty($apikey)) {
+			$client_opts[CURLOPT_HTTPHEADER] = ["X-Ojs-Sword-Api-Token:".$apikey];
+		}
+		$client = new SWORDAPPClient($client_opts);
 		$response = $client->deposit(
 			$url, $username, $password,
 			'',

--- a/classes/OJSSwordDeposit.inc.php
+++ b/classes/OJSSwordDeposit.inc.php
@@ -175,12 +175,9 @@ class OJSSwordDeposit {
 	 * @param $username string SWORD deposit username (i.e. email address for DSPACE)
 	 * @param $password string SWORD deposit password
 	 */
-	public function deposit($url, $username, $password, $apikey = '') {
-		$client_opts = array();
-		if (!empty($apikey)) {
-			$client_opts[CURLOPT_HTTPHEADER] = ["X-Ojs-Sword-Api-Token:".$apikey];
-		}
-		$client = new SWORDAPPClient($client_opts);
+	public function deposit($url, $username, $password, $apikey = null) {
+		$clientOpts = $apikey ? [CURLOPT_HTTPHEADER => ["X-Ojs-Sword-Api-Token:".$apikey]] : array();
+		$client = new SWORDAPPClient($clientOpts);
 		$response = $client->deposit(
 			$url, $username, $password,
 			'',

--- a/js/SwordDepositPointsFormHandler.js
+++ b/js/SwordDepositPointsFormHandler.js
@@ -77,6 +77,10 @@
 					$("select#swordDepositPoint").append(opt);
 				}
 				$('span#depositPointsSpinner').removeClass('is_visible');
+				$.event.trigger({
+					type: "pkp.plugins.sword.loadDepositPoint",
+					depositPointId: selectedDepositPoint
+				});
 			}, 'json');
 		}
 

--- a/js/SwordDepositPointsFormHandler.js
+++ b/js/SwordDepositPointsFormHandler.js
@@ -69,15 +69,16 @@
 				var content = data.content;
 				$('input[name=swordUsername]').val(content.username);
 				$('input[name=swordPassword]').val(content.password);
+				$('input[name=swordApiKey]').val(content.apikey);
 				for (dp in content.depositPoints) {
 					var value = dp;
 					var label = content.depositPoints[dp];
 					var opt = $('<option/>').val(value).text(label);
 					$("select#swordDepositPoint").append(opt);
-					$('span#depositPointsSpinner').removeClass('is_visible');
 				}
+				$('span#depositPointsSpinner').removeClass('is_visible');
 			}, 'json');
-		} 
+		}
 
 	/**
 	 * Callback to load deposit points details
@@ -85,7 +86,7 @@
 	 * @private
 	 */
 	$.pkp.plugins.sword.js.SwordDepositPointsFormHandler.prototype.
-		selectAllSubmissions = 
+		selectAllSubmissions =
 		function() {
 			$('div.pkpListPanel--selectSubmissions input[type=checkbox]').prop('checked',true);
 		}

--- a/js/SwordDisableDepositedItems.js
+++ b/js/SwordDisableDepositedItems.js
@@ -1,0 +1,20 @@
+(function($) {
+	var depositPointMap;
+	$(document).ready(function() {
+		depositPointMap = $(document).data('depositedIdMap');
+	});
+
+	$(document).on('pkp.plugins.sword.loadDepositPoint', function(e) {
+		depositPointId = parseInt(e.depositPointId);
+		$.each($('.pkpListPanel--selectSubmissions li.pkpListPanelItem--selectSubmission'), function(i, $li) {
+			var submissionId = parseInt($("input", $li).val());
+			if (_.has(depositPointMap, submissionId)) {
+				if (_.has(depositPointMap[submissionId], depositPointId)) {
+					$("input", $li).attr('disabled', true);
+				} else {
+					$("input", $li).removeAttr('disabled');
+				}
+			}
+		});
+	});
+}(jQuery));

--- a/js/SwordEditDepositPointsFormHandler.js
+++ b/js/SwordEditDepositPointsFormHandler.js
@@ -38,31 +38,31 @@
 	 * @param {jQueryObject} $form the wrapped HTML form element.
 	 */
 	$.pkp.plugins.sword.js.SwordEditDepositPointsFormHandler =
-		function($form) {
-			$swordUsername = $form.find( "input[name='swordUsername'] ");
-			$swordPassword = $form.find( "input[name='swordPassword'] ");
-			$swordApikey = $form.find( "input[name='swordApikey'] ");
+			function($form) {
+		$swordUsername = $form.find( "input[name='swordUsername'] ");
+		$swordPassword = $form.find( "input[name='swordPassword'] ");
+		$swordApikey = $form.find( "input[name='swordApikey'] ");
 
-			$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
-				$input.change(function(e) {
-					$this = $(this);
-					$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
-						$.each($("label[for='"+$input[0].id+"']").slice(1), function(i, labelDOM) {
-							labelDOM.remove();
-						});
+		$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+			$input.change(function(e) {
+				$this = $(this);
+				$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+					$.each($("label[for='"+$input[0].id+"']").slice(1), function(i, labelDOM) {
+						labelDOM.remove();
 					});
-
-					if (invalidFormState($swordUsername, $swordPassword, $swordApikey)) {
-						$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
-							if (!$input[0].value.length) {
-								showFieldError($input);
-							}
-						});
-						$('button.submitFormButton').attr('disabled', true);
-					} else {
-						$('button.submitFormButton').removeAttr('disabled');
-					}
 				});
+
+				if (invalidFormState($swordUsername, $swordPassword, $swordApikey)) {
+					$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+						if (!$input[0].value.length) {
+							showFieldError($input);
+						}
+					});
+					$('button.submitFormButton').attr('disabled', true);
+				} else {
+					$('button.submitFormButton').removeAttr('disabled');
+				}
 			});
-		}
+		});
+	}
 }(jQuery));

--- a/js/SwordEditDepositPointsFormHandler.js
+++ b/js/SwordEditDepositPointsFormHandler.js
@@ -1,0 +1,68 @@
+/**
+ * @file js/SwordEditDepositPointsFormHandler.js
+ *
+ * Copyright (c) 2014-2019 Simon Fraser University
+ * Copyright (c) 2000-2019 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @package plugins.generic.sword
+ * @class SwordEditDepositPointsFormHandler
+ *
+ * @brief SWORD plugin deposit points form handler.
+ */
+(function($) {
+	/** @type {Object} */
+	$.pkp.plugins.sword =
+			$.pkp.plugins.sword ||
+			{ js: { } };
+
+	function showFieldError($input) {
+		label = $($.parseHTML("<label for='"+$input[0].id+"'><span class='error'>"+$input.data('error')+"</span></label>"));
+		$input.after(label[0]);
+	}
+
+	function invalidFormState($usernameInput, $passwordInput, $apikeyInput) {
+		if($usernameInput[0].value.length && $passwordInput[0].value.length) {
+			return false;
+		} else if (Math.max($usernameInput[0].value.length, $passwordInput[0].value.length)) {
+			return true;
+		} else if ($apikeyInput[0].value.length) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @constructor
+	 *
+	 * @param {jQueryObject} $form the wrapped HTML form element.
+	 */
+	$.pkp.plugins.sword.js.SwordEditDepositPointsFormHandler =
+		function($form) {
+			$swordUsername = $form.find( "input[name='swordUsername'] ");
+			$swordPassword = $form.find( "input[name='swordPassword'] ");
+			$swordApikey = $form.find( "input[name='swordApikey'] ");
+
+			$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+				$input.change(function(e) {
+					$this = $(this);
+					$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+						$.each($("label[for='"+$input[0].id+"']").slice(1), function(i, labelDOM) {
+							labelDOM.remove();
+						});
+					});
+
+					if (invalidFormState($swordUsername, $swordPassword, $swordApikey)) {
+						$.each([$swordUsername, $swordPassword, $swordApikey], function(i, $input) {
+							if (!$input[0].value.length) {
+								showFieldError($input);
+							}
+						});
+						$('button.submitFormButton').attr('disabled', true);
+					} else {
+						$('button.submitFormButton').removeAttr('disabled');
+					}
+				});
+			});
+		}
+}(jQuery));

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -21,6 +21,7 @@
 	<message key="plugins.generic.sword.settings.depositPoints">Deposit Points</message>
 	<message key="plugins.generic.sword.depositPoints.create">Create Deposit Point</message>
 	<message key="plugins.generic.sword.depositPoints.edit">Edit Deposit Point</message>
+	<message key="plugins.generic.sword.depositPoints.apikey">API Key</message>
 	<message key="plugins.generic.sword.depositPoints.type.automatic">Automatic</message>
 	<message key="plugins.generic.sword.depositPoints.type.optionalSelection">Optional; Flexible</message>
 	<message key="plugins.generic.sword.depositPoints.type.optionalFixed">Optional; Fixed</message>
@@ -41,6 +42,7 @@
 	<message key="plugins.importexport.sword.displayName">SWORD Import/Export Deposit Plugin</message>
 	<message key="plugins.importexport.sword.description">Deposit articles in remote repositories using the SWORD deposit protocol</message>
 	<message key="plugins.importexport.sword.deposit">Deposit</message>
+	<message key="plugins.importexport.sword.apikey">API Key</message>
 	<message key="plugins.importexport.sword.serviceDocUrl">Service Document URL</message>
 	<message key="plugins.importexport.sword.depositUrl">Deposit Point URL</message>
 	<message key="plugins.importexport.sword.depositPoint">Deposit Point</message>
@@ -55,4 +57,7 @@
 	<message key="plugins.importexport.sword.requiredFieldErrorMessage">Please select at least one submission to deposit.</message>
 	<message key="plugins.generic.sword.settings.saved">Settings saved!</message>
 	<message key="plugins.generic.sword.manager.noneCreated">No deposit points have been created.</message>
+	<message key="plugins.generic.sword.formErrors.username">Username required if password is present or api key is empty.</message>
+	<message key="plugins.generic.sword.formErrors.password"> Password required if username is present or api key is empty.</message>
+	<message key="plugins.generic.sword.formErrors.apikey">Api key required unless username and password are present.</message>
 </locale>

--- a/schema.xml
+++ b/schema.xml
@@ -16,7 +16,7 @@
 
 	<!--
 	 *
-	 * TABLE deposit_points 
+	 * TABLE deposit_points
 	 *
 	 -->
 	<table name="deposit_points">
@@ -42,6 +42,9 @@
 			<NOTNULL/>
 		</field>
 		<field name="sword_password" type="C2" size="2047">
+			<NOTNULL/>
+		</field>
+		<field name="sword_apikey" type="C2" size="2047">
 			<NOTNULL/>
 		</field>
 		<descr>Deposit points.</descr>

--- a/templates/articles.tpl
+++ b/templates/articles.tpl
@@ -8,7 +8,6 @@
  * Deposit articles in remote repositories
  *}
 {include file="common/header.tpl" pageTitle="plugins.importexport.sword.displayName"}
- 
 <script src="{$pluginJavaScriptURL}/SwordDepositPointsFormHandler.js"></script>
 <script type="text/javascript">
 	$(function() {ldelim}

--- a/templates/articles.tpl
+++ b/templates/articles.tpl
@@ -42,6 +42,9 @@
 				{fbvFormSection for="swordPassword" title="user.password"}
 					{fbvElement type="text" password="true" id="swordPassword" value=$swordPassword|escape}
 				{/fbvFormSection}
+				{fbvFormSection for="swordApiKey" title="plugins.importexport.sword.apikey"}
+					{fbvElement type="text" id="swordApiKey" value=$swordApiKey}
+				{/fbvFormSection}
 				{fbvFormSection title="plugins.importexport.sword.depositPoint"}
 					{fbvElement type="select" id="swordDepositPoint" translate=false}
 					{fbvElement type="button" label="common.refresh" id="refreshBtn" inline=true}

--- a/templates/editDepositPointForm.tpl
+++ b/templates/editDepositPointForm.tpl
@@ -7,12 +7,16 @@
  *
  * Form for editing a deposit point
  *}
- 
+
+<script src="{$pluginJavaScriptURL}/SwordEditDepositPointsFormHandler.js"></script>
  <script type="text/javascript">
 	$(function() {ldelim}
 		// Attach the form handler.
 		$('#depositPointForm').pkpHandler(
 			'$.pkp.controllers.form.AjaxFormHandler'
+		);
+		$('#depositPointForm').pkpHandler(
+			'$.pkp.plugins.sword.js.SwordEditDepositPointsFormHandler'
 		);
 	{rdelim});
 </script>
@@ -30,25 +34,29 @@
 		{fbvFormSection for="name" title="plugins.generic.sword.depositPoints.name"}
 			{fbvElement type="text" id="name" name="name" value=$name multilingual=true}
 		{/fbvFormSection}
-		
+
 		{fbvFormSection for="swordUrl" title="plugins.importexport.sword.depositUrl"}
 			{fbvElement type="text" id="swordUrl" value=$swordUrl}
 		{/fbvFormSection}
-		
+
 		{fbvFormSection for="swordUsername" title="user.username"}
-			{fbvElement type="text" id="swordUsername" value=$swordUsername}
+			{fbvElement type="text" id="swordUsername" value=$swordUsername data-error="{translate key='plugins.generic.sword.formErrors.username'}"}
 		{/fbvFormSection}
-		
+
 		{fbvFormSection for="swordPassword" title="user.password"}
-			{fbvElement type="text" password="true" id="swordPassword" value=$swordPassword}
+			{fbvElement type="text" password="true" id="swordPassword" value=$swordPassword data-error="{translate key='plugins.generic.sword.formErrors.password'}"}
 		{/fbvFormSection}
-		
+
+		{fbvFormSection for="swordApikey" title="plugins.generic.sword.depositPoints.apikey"}
+			{fbvElement type="text" id="swordApikey" value=$swordApikey data-error="{translate key='plugins.generic.sword.formErrors.apikey'}"}
+		{/fbvFormSection}
+
 		{fbvFormSection title="common.type"}
 			{fbvElement type="select" id="depositPointType" from=$depositPointTypes selected=$selectedType translate=false}
 		{/fbvFormSection}
-		
+
 		{fbvFormSection description="plugins.generic.sword.depositPoints.type.description"}{/fbvFormSection}
 	{/fbvFormSection}
-	
+
 	{fbvFormButtons id="depositPointSubmit" submitText="common.save"}
 </form>


### PR DESCRIPTION
Work in progress. Adds functionality to capture the SWORD Statement IRI after a successful deposit and store it in the `submission_settings` table. Can store a single IRI for each Deposit Point. Also adds UI functionality to prevent user from depositing to the same DepositPoint if there is already a statement IRI for that DepositPoint. (This wouldn't prevent a redundant deposit if two Deposit Points had the same URL, or if a Deposit Point record were edited between deposits). I'm not sure about this - just wanted to do something basic to reflect the capability to keep track of the deposit.